### PR TITLE
Add migration to change type and name of games_status_id

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -20,6 +20,6 @@ class GamesController < ApplicationController
   private
 
   def game_params
-    params.require(:game).permit(:white_player, :black_player, :game_status_id)
+    params.require(:game).permit(:white_player, :black_player, :game_status)
   end
 end

--- a/bin/rails
+++ b/bin/rails
@@ -1,15 +1,4 @@
 #!/usr/bin/env ruby
-if ENV['RAILS_ENV'] == 'test'
-  require 'simplecov'
-  SimpleCov.start 'rails'
-  puts "required simplecov"
-end
-
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/db/migrate/20170705213845_change_type_and_name_of_games_status_id.rb
+++ b/db/migrate/20170705213845_change_type_and_name_of_games_status_id.rb
@@ -1,0 +1,6 @@
+class ChangeTypeAndNameOfGamesStatusId < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :games, :game_status_id, :game_status
+    change_column :games, :game_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170705182352) do
+ActiveRecord::Schema.define(version: 20170705213845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,9 +18,9 @@ ActiveRecord::Schema.define(version: 20170705182352) do
   create_table "games", force: :cascade do |t|
     t.integer  "white_player"
     t.integer  "black_player"
-    t.integer  "game_status_id"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.string   "game_status"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
   end
 
   create_table "moves", force: :cascade do |t|


### PR DESCRIPTION
1. Since we do not have a `games_status` table, this is not a foreign key and we do not need `_id`
2. Since it is a local field, `games_status` should be a string and not an integer.