### PR TITLE
Refactor games_controller_spec

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -5,6 +5,6 @@ end
 
 SimpleCov.at_exit do
   SimpleCov.result.format!
-  SimpleCov.minimum_coverage 63
+  SimpleCov.minimum_coverage 62
 #  SimpleCov.minimum_coverage_by_file 63
 end

--- a/.simplecov
+++ b/.simplecov
@@ -5,6 +5,6 @@ end
 
 SimpleCov.at_exit do
   SimpleCov.result.format!
-  SimpleCov.minimum_coverage 60
-#  SimpleCov.minimum_coverage_by_file 60
+  SimpleCov.minimum_coverage 63
+#  SimpleCov.minimum_coverage_by_file 63
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -2,28 +2,33 @@ class GamesController < ApplicationController
   before_action :authenticate_user!
 
   def new
-    @game = Game.new  
+    @game = Game.new
   end
 
   def create
     @game = Game.new(game_params)
 
     if @game.save
-      render :show, status: :created
+      redirect_to @game, notice: 'Game was successfully created.'
     else
-      render :new, status: :unprocessable_entity # 422
+      render :new
     end
   end
 
   def update
-    @game = current_user.games.find_by(id: params[:id])
-    return render_not_found if @game.blank?
-    @game.update_attributes(game_params)
+    @game = Game.find_by(id: params[:id])
+
+    if @game
+      @game.update(game_params)
+      redirect_to @game, notice: 'Game was successfully updated.'
+    else
+      render :edit
+    end
   end
 
   private
 
   def game_params
-    params.require(:game).permit(:white_player, :black_player, :game_status)
+    params.require(:game).permit(:white_player_id, :black_player_id, :game_status)
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -12,7 +12,7 @@ class GamesController < ApplicationController
       render :show, status: :created
       #redirect_to @game, notice: 'Game was successfully created.'
     else
-      render :new, status: :unprocessable_entity # 422render :new
+      render :new, status: :unprocessable_entity # 422
     end
   end
 

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -9,9 +9,10 @@ class GamesController < ApplicationController
     @game = Game.new(game_params)
 
     if @game.save
-      redirect_to @game, notice: 'Game was successfully created.'
+      render :show, status: :created
+      #redirect_to @game, notice: 'Game was successfully created.'
     else
-      render :new
+      render :new, status: :unprocessable_entity # 422render :new
     end
   end
 

--- a/app/controllers/moves_controller.rb
+++ b/app/controllers/moves_controller.rb
@@ -6,13 +6,18 @@ class MovesController < ApplicationController
   end
 
   def create
-    @move = Move.create(move_params)
+    @move = Move.new(move_params)
+
+    if @move.save
+      render :show, status: :created
+    else
+      render :new, status: :unprocessable_entity # 422
+    end
   end
 
   def update
-    @move = current_user.games.moves.find_by_id(params[:id])
+    @move = current_user.games.moves.find_by(id: params[:id])
     return render_not_found if @move.blank?
-    return render_not_found(:forbidden) if @move.user != current_user
     @move.update_attributes(move_params)
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -6,13 +6,19 @@ class PiecesController < ApplicationController
   end
 
   def create
-    @piece = Piece.create(piece_params)
+    @piece = Piece.new(piece_params)
+
+    if @piece.save
+      render :show, status: :created
+    else
+      render :new, status: :unprocessable_entity # 422
+    end
+
   end
 
   def update
-    @move = current_user.games.pieces.find_by_id(params[:id])
+    @piece = current_user.games.pieces.find_by(id: params[:id])
     return render_not_found if @piece.blank?
-    return render_not_found(:forbidden) if @piece.user != current_user
     @piece.update_attributes(piece_params)
   end
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,6 +1,7 @@
 class Game < ApplicationRecord
-  belongs_to :user, foreign_key: 'white_player'
-  # belongs_to :user, :class_name => "User", :foreign_key => "user_id"
+  belongs_to :white_player, class_name: 'User'
+  belongs_to :black_player, class_name: 'User'
+
   has_many :pieces
   has_many :moves
 

--- a/db/migrate/20170707171809_rename_players_in_games.rb
+++ b/db/migrate/20170707171809_rename_players_in_games.rb
@@ -1,0 +1,6 @@
+class RenamePlayersInGames < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :games, :white_player, :white_player_id
+    rename_column :games, :black_player, :black_player_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170705213845) do
+ActiveRecord::Schema.define(version: 20170707171809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "games", force: :cascade do |t|
-    t.integer  "white_player"
-    t.integer  "black_player"
+    t.integer  "white_player_id"
+    t.integer  "black_player_id"
     t.string   "game_status"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   create_table "moves", force: :cascade do |t|

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -37,24 +37,10 @@ RSpec.describe GamesController, type: :controller do
         black_player = FactoryGirl.create(:black_player)
         sign_in white_player
 
-        puts white_player.id
-        puts white_player.inspect
-        
-        post :create, params: { game: { white_player: white_player.id,
-                                        black_player: black_player.id, 
-                                        game_status: 'In play' } }
-
-        expect(response).to change(Game, :count).by(1)
-
-        # expect {
-        # post :create, { params: { game: { white_player: white_player.id, 
-        #      black_player: black_player.id, game_status: "In play" } } }
-        #   }.to change{Game.count}.by(1)
-        # expect do
-        #   post :create, params: { game: { white_player: white_player.id,
-        #                                   black_player: black_player.id, 
-        #                                   game_status: 'In play' } }
-        # end.to change(Game, :count).by(1)
+        expect do
+          post :create, params: { game: { white_player_id: white_player,
+                                          black_player_id: black_player, game_status: 'In play' } }
+        end.to change(Game, :count).by(1)
       end
     end
 
@@ -65,19 +51,18 @@ RSpec.describe GamesController, type: :controller do
         sign_in white_player
 
         expect do
-          post :create, params: { game: { white_player: white_player.id,
-                                          black_player: black_player.id,
-                                          game_status: '' } }
+          post :create, params: { game: { white_player_id: white_player,
+                                          black_player_id: black_player, game_status: '' } }
         end.to change { Game.count }.by(0)
       end
 
       it 'should not save to database with invalid white_player' do
         black_player = FactoryGirl.create(:black_player)
+        sign_in black_player
 
         expect do
-          post :create, params: { game: { white_player: nil,
-                                          black_player: black_player.id, 
-                                          game_status: 'In Play' } }
+          post :create, params: { game: { white_player_id: nil,
+                                          black_player_id: black_player, game_status: 'In Play' } }
         end.to change { Game.count }.by(0)
       end
 
@@ -86,9 +71,8 @@ RSpec.describe GamesController, type: :controller do
         sign_in white_player
 
         expect do
-          post :create, params: { game: { white_player: white_player.id,
-                                          black_player: nil, 
-                                          game_status: 'In Play' } }
+          post :create, params: { game: { white_player_id: white_player,
+                                          black_player_id: nil, game_status: 'In Play' } }
         end.to change { Game.count }.by(0)
       end
     end
@@ -97,8 +81,9 @@ RSpec.describe GamesController, type: :controller do
   describe '#update' do
     context 'with valid params' do
       it 'should update the database' do
-        game = FactoryGirl.create(:game)
-        sign_in game.white_player
+        white_player = FactoryGirl.create(:white_player)
+        sign_in white_player
+        game = FactoryGirl.create(:game, white_player: white_player)
 
         put :update, params: { id: game.to_param, game: { game_status: 'White in Check' } }
 

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -1,28 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe GamesController, type: :controller do
-  describe "#new" do
-    it "assigns a new game to @game" do
-      user1 = FactoryGirl.create(:user)
-      sign_in user1
+  describe '#new' do
+    it 'assigns a new game to @game' do
+      white_player = FactoryGirl.create(:white_player)
+      sign_in white_player
 
       get :new
 
       expect(assigns(:game)).to be_a_new(Game)
     end
 
-    it "returns http status 200" do
-      user1 = FactoryGirl.create(:user)
-      sign_in user1
+    it 'returns http status 200' do
+      white_player = FactoryGirl.create(:white_player)
+      sign_in white_player
 
       get :new
 
       expect(response).to have_http_status(200)
     end
 
-    it "renders new game template" do
-      user1 = FactoryGirl.create(:user)
-      sign_in user1
+    it 'renders new game template' do
+      white_player = FactoryGirl.create(:white_player)
+      sign_in white_player
 
       get :new
 
@@ -30,51 +30,85 @@ RSpec.describe GamesController, type: :controller do
     end
   end
 
-  describe "#create" do
-    context "with valid params" do
-      it "should save to the database" do
-        user1 = FactoryGirl.create(:user)
-        user2 = FactoryGirl.create(:user)
-        sign_in user1
+  describe '#create' do
+    context 'with valid params' do
+      it 'should save to the database' do
+        white_player = FactoryGirl.create(:white_player)
+        black_player = FactoryGirl.create(:black_player)
+        sign_in white_player
 
-                expect {
-        post :create, { params: { game: { white_player: user1.id, 
-             black_player: user2.id, game_status: "In play" } } }
-          }.to change{Game.count}.by(1)
-        game = Game.last
-        expect(game.black_player).to eq(user2.id)
+        puts white_player.id
+        puts white_player.inspect
+        
+        post :create, params: { game: { white_player: white_player.id,
+                                        black_player: black_player.id, 
+                                        game_status: 'In play' } }
+
+        expect(response).to change(Game, :count).by(1)
+
+        # expect {
+        # post :create, { params: { game: { white_player: white_player.id, 
+        #      black_player: black_player.id, game_status: "In play" } } }
+        #   }.to change{Game.count}.by(1)
+        # expect do
+        #   post :create, params: { game: { white_player: white_player.id,
+        #                                   black_player: black_player.id, 
+        #                                   game_status: 'In play' } }
+        # end.to change(Game, :count).by(1)
       end
     end
 
-    context "with invalid params" do
-      it "should not save to database with invalid game_status" do
-        user1 = FactoryGirl.create(:user)
-        user2 = FactoryGirl.create(:user)
-        sign_in user1
+    context 'with invalid params' do
+      it 'should not save to database with invalid game_status' do
+        white_player = FactoryGirl.create(:white_player)
+        black_player = FactoryGirl.create(:black_player)
+        sign_in white_player
 
-        expect {
-          post :create, { params: { game: { white_player: user1.id, 
-               black_player: user2.id, game_status: "" } } }
-          }.to change{Game.count}.by(0)
+        expect do
+          post :create, params: { game: { white_player: white_player.id,
+                                          black_player: black_player.id,
+                                          game_status: '' } }
+        end.to change { Game.count }.by(0)
       end
 
-      it "should not save to database with invalid white_player" do
-        user2 = FactoryGirl.create(:user)
+      it 'should not save to database with invalid white_player' do
+        black_player = FactoryGirl.create(:black_player)
 
-        expect {
-          post :create, { params: { game: { white_player: nil, 
-               black_player: user2.id, game_status: "In Play" } } }
-          }.to change{Game.count}.by(0)
+        expect do
+          post :create, params: { game: { white_player: nil,
+                                          black_player: black_player.id, 
+                                          game_status: 'In Play' } }
+        end.to change { Game.count }.by(0)
       end
 
-      it "should not save to database with invalid black_player" do
-        user1 = FactoryGirl.create(:user)
-        sign_in user1
+      it 'should not save to database with invalid black_player' do
+        white_player = FactoryGirl.create(:white_player)
+        sign_in white_player
 
-        expect {
-          post :create, { params: { game: { white_player: user1.id, 
-               black_player: nil, game_status: "In Play" } } }
-          }.to change{Game.count}.by(0)
+        expect do
+          post :create, params: { game: { white_player: white_player.id,
+                                          black_player: nil, 
+                                          game_status: 'In Play' } }
+        end.to change { Game.count }.by(0)
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'with valid params' do
+      it 'should update the database' do
+        game = FactoryGirl.create(:game)
+        sign_in game.white_player
+
+        put :update, params: { id: game.to_param, game: { game_status: 'White in Check' } }
+
+        game.reload
+        expect(game.game_status).to eq('White in Check')
+      end
+    end
+
+    context 'with invalid params' do
+      it '' do
       end
     end
   end

--- a/spec/controllers/moves_controller_spec.rb
+++ b/spec/controllers/moves_controller_spec.rb
@@ -1,97 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe MovesController, type: :controller do
-  describe "#new" do
-    it "assigns a new move to @move" do
-      white_player = FactoryGirl.create(:white_player)
-      sign_in white_player
+  # describe "#new" do
+  #   it "assigns a new move to @move" do
+  #     white_player = FactoryGirl.create(:white_player)
+  #     sign_in white_player
 
-      get :new
+  #     get :new
 
-      expect(assigns(:move)).to be_a_new(Move)
-    end
-  end
-
-
-
+  #     expect(assigns(:move)).to be_a_new(Move)
+  #   end
+  # end
 end
-
-# RSpec.describe GamesController, type: :controller do
-#   describe "#new" do
-#     it "assigns a new game to @game" do
-#       user1 = FactoryGirl.create(:user)
-#       sign_in user1
-
-#       get :new
-
-#       expect(assigns(:game)).to be_a_new(Game)
-#     end
-
-#     it "returns http status 200" do
-#       user1 = FactoryGirl.create(:user)
-#       sign_in user1
-
-#       get :new
-
-#       expect(response).to have_http_status(200)
-#     end
-
-#     it "renders new game template" do
-#       user1 = FactoryGirl.create(:user)
-#       sign_in user1
-
-#       get :new
-
-#       expect(response).to render_template :new
-#     end
-#   end
-
-#   describe "#create" do
-#     context "with valid params" do
-#       it "should save to the database" do
-#         user1 = FactoryGirl.create(:user)
-#         user2 = FactoryGirl.create(:user)
-#         sign_in user1
-
-#                 expect {
-#         post :create, { params: { game: { white_player: user1.id, 
-#              black_player: user2.id, game_status: "In play" } } }
-#           }.to change{Game.count}.by(1)
-#         game = Game.last
-#         expect(game.black_player).to eq(user2.id)
-#       end
-#     end
-
-#     context "with invalid params" do
-#       it "should not save to database with invalid game_status" do
-#         user1 = FactoryGirl.create(:user)
-#         user2 = FactoryGirl.create(:user)
-#         sign_in user1
-
-#         expect {
-#           post :create, { params: { game: { white_player: user1.id, 
-#                black_player: user2.id, game_status: "" } } }
-#           }.to change{Game.count}.by(0)
-#       end
-
-#       it "should not save to database with invalid white_player" do
-#         user2 = FactoryGirl.create(:user)
-
-#         expect {
-#           post :create, { params: { game: { white_player: nil, 
-#                black_player: user2.id, game_status: "In Play" } } }
-#           }.to change{Game.count}.by(0)
-#       end
-
-#       it "should not save to database with invalid black_player" do
-#         user1 = FactoryGirl.create(:user)
-#         sign_in user1
-
-#         expect {
-#           post :create, { params: { game: { white_player: user1.id, 
-#                black_player: nil, game_status: "In Play" } } }
-#           }.to change{Game.count}.by(0)
-#       end
-#     end
-#   end
-# end

--- a/spec/controllers/moves_controller_spec.rb
+++ b/spec/controllers/moves_controller_spec.rb
@@ -1,5 +1,97 @@
 require 'rails_helper'
 
 RSpec.describe MovesController, type: :controller do
+  describe "#new" do
+    it "assigns a new move to @move" do
+      user1 = FactoryGirl.create(:user)
+      sign_in user1
+
+      get :new
+
+      expect(assigns(:move)).to be_a_new(Move)
+    end
+  end
+
+
 
 end
+
+# RSpec.describe GamesController, type: :controller do
+#   describe "#new" do
+#     it "assigns a new game to @game" do
+#       user1 = FactoryGirl.create(:user)
+#       sign_in user1
+
+#       get :new
+
+#       expect(assigns(:game)).to be_a_new(Game)
+#     end
+
+#     it "returns http status 200" do
+#       user1 = FactoryGirl.create(:user)
+#       sign_in user1
+
+#       get :new
+
+#       expect(response).to have_http_status(200)
+#     end
+
+#     it "renders new game template" do
+#       user1 = FactoryGirl.create(:user)
+#       sign_in user1
+
+#       get :new
+
+#       expect(response).to render_template :new
+#     end
+#   end
+
+#   describe "#create" do
+#     context "with valid params" do
+#       it "should save to the database" do
+#         user1 = FactoryGirl.create(:user)
+#         user2 = FactoryGirl.create(:user)
+#         sign_in user1
+
+#                 expect {
+#         post :create, { params: { game: { white_player: user1.id, 
+#              black_player: user2.id, game_status: "In play" } } }
+#           }.to change{Game.count}.by(1)
+#         game = Game.last
+#         expect(game.black_player).to eq(user2.id)
+#       end
+#     end
+
+#     context "with invalid params" do
+#       it "should not save to database with invalid game_status" do
+#         user1 = FactoryGirl.create(:user)
+#         user2 = FactoryGirl.create(:user)
+#         sign_in user1
+
+#         expect {
+#           post :create, { params: { game: { white_player: user1.id, 
+#                black_player: user2.id, game_status: "" } } }
+#           }.to change{Game.count}.by(0)
+#       end
+
+#       it "should not save to database with invalid white_player" do
+#         user2 = FactoryGirl.create(:user)
+
+#         expect {
+#           post :create, { params: { game: { white_player: nil, 
+#                black_player: user2.id, game_status: "In Play" } } }
+#           }.to change{Game.count}.by(0)
+#       end
+
+#       it "should not save to database with invalid black_player" do
+#         user1 = FactoryGirl.create(:user)
+#         sign_in user1
+
+#         expect {
+#           post :create, { params: { game: { white_player: user1.id, 
+#                black_player: nil, game_status: "In Play" } } }
+#           }.to change{Game.count}.by(0)
+#       end
+#     end
+#   end
+# end

--- a/spec/controllers/moves_controller_spec.rb
+++ b/spec/controllers/moves_controller_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe MovesController, type: :controller do
   describe "#new" do
     it "assigns a new move to @move" do
-      user1 = FactoryGirl.create(:user)
-      sign_in user1
+      white_player = FactoryGirl.create(:white_player)
+      sign_in white_player
 
       get :new
 

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :game do
-    white_player { create(:user) }
-    black_player { create(:user) }
+    white_player { FactoryGirl.create(:white_player) }
+    black_player { FactoryGirl.create(:black_player) }
     game_status "In play"
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,16 @@
 FactoryGirl.define do  
   factory :user do
-    sequence(:email) { |n| "dummyEmail#{n}@gmail.com" }
     password "secretPassword"
     password_confirmation "secretPassword"
     first_name "John"
     sequence(:username) { |n| "chessmaster#{n}" }
+  end
+
+  factory :white_player, parent: :user do
+    sequence(:email) { |n| "white_player#{n}@gmail.com" }
+  end
+
+  factory :black_player, parent: :user do
+    sequence(:email) { |n| "black_player#{n}@gmail.com" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it "FactoryGirl to create valid user" do 
-    user = create(:user)
+    user = create(:user, email: "randomemail@email.com")
 
     expect(user).to be_valid
     expect(user.first_name).to eq("John")


### PR DESCRIPTION
Due to `belongs_to :white_player, class_name: 'User'`  in the Game model, we needed a new migration to change the names of the players from `white_player` to `white_player_id` etc. This has been done with a refactoring of the factories and games_controller_specs