### PR TITLE
Fix Production Asset Error

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '717e6e7e9d3b0d733602f6a6ab981379c20241a0e20938974d29c67e9bf2dcd84615f061eca4e28c2a1eb41f4fa8dbce0b792751e23210be798fec72c5334c83'
+  config.secret_key = '717e6e7e9d3b0d733602f6a6ab981379c20241a0e20938974d29c67e9bf2dcd84615f061eca4e28c2a1eb41f4fa8dbce0b792751e23210be798fec72c5334c83'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
Heroku asset pipeline debugging by running the following command:
`$ RAILS_ENV=production bundle exec rake assets:precompile`

This produced an error message regarding the devise secret key. It was commented out so I removed the comment, re-ran the command, and all assets began to compile properly.