### PR TITLE
Additional Asset Pipeline Configuration

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
  */
  
  @import "foundation_and_overrides";
+ @import "index.scss";
 
 .top-bar, .menu-text {
   background-color: #A9A9A9;

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -1,5 +1,5 @@
 .about-chess {
-  background: linear-gradient(to bottom, rgba(13, 175, 129, 0.1) 0%, rgba(13, 175, 129, 0.1) 100%), url('chessboard.jpg') no-repeat center center fixed;
+  background: linear-gradient(to bottom, rgba(13, 175, 129, 0.1) 0%, rgba(13, 175, 129, 0.1) 100%), image_url('chessboard.jpg') no-repeat center center fixed;
   -webkit-background-size: cover;
   -moz-background-size: cover;
   -o-background-size: cover;

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,8 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.serve_static_assets = true
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
This is a follow up to [Pull Request #29 ](https://github.com/warandpiece/chessapp/pull/29) (Fix Production Asset Error.) Although those modifications were needed, it did not resolve the issue and I have further debugged to properly configure the app for assets.

- Modified `url` to `image_url`  to comply to Ruby syntax
- Added `@import "index.scss";` to `application.scss`
- Added lines to production.rb for the assets pipeline