### PR TITLE
fixed bug on obstruction method

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -24,7 +24,7 @@ class Piece < ApplicationRecord
 
   def is_horizontal_move_blocked(destination_x)    
     destination_x > self.current_position_x ? dir_x = 1 : dir_x = -1
-    (1..(destination_x - self.current_position_x).abs).each do |i|
+    (1..((destination_x - dir_x) - self.current_position_x ).abs).each do |i|
       x = self.current_position_x + i * dir_x
       return true if Piece.find_by(current_position_x: x, current_position_y: self.current_position_y)
     end
@@ -33,7 +33,7 @@ class Piece < ApplicationRecord
 
   def is_vertical_move_blocked(destination_y)
     destination_y > self.current_position_y ? dir_y = 1 : dir_y = -1
-    (1..(destination_y - self.current_position_y).abs).each do |i|
+    (1..((destination_y - dir_y) - self.current_position_y).abs).each do |i|
       y = self.current_position_y + i * dir_y
       return true if Piece.find_by(current_position_x: self.current_position_x, current_position_y: y)
     end
@@ -43,7 +43,7 @@ class Piece < ApplicationRecord
   def is_diagonal_move_blocked(destination_x, destination_y)
     destination_x > self.current_position_x ? dir_x = 1 : dir_x = -1
     destination_y > self.current_position_y ? dir_y = 1 : dir_y = -1
-    (1..(destination_x - self.current_position_x).abs).each do |i|
+    (1..((destination_x - dir_x) - self.current_position_x).abs).each do |i|
       x = self.current_position_x + i * dir_x
       y = self.current_position_y + i * dir_y
       return true if Piece.find_by(current_position_x: x, current_position_y: y)

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -54,21 +54,45 @@ RSpec.describe Piece, type: :model do
     context 'left to right' do
       let!(:rook1) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 0) }
       let!(:rook2) { FactoryGirl.create(:rook, current_position_x: 3, current_position_y: 0) }
+      let!(:rook3) { FactoryGirl.create(:rook, current_position_x: 5, current_position_y: 0) }
       let(:dest_x) { 5 }
       let(:dest_y) { 0 }
       it 'should return true (move 0,0 to 5,0 blocked on 3,0)' do
         expect(rook1.is_move_blocked(dest_x,dest_y)).to be true
       end
     end
+    
+    context 'left to right - edge case - piece on destination position' do
+      let!(:rook1) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 0) }
+      let!(:rook2) { FactoryGirl.create(:rook, current_position_x: 3, current_position_y: 0) }
+      let(:dest_x) { 3 }
+      let(:dest_y) { 0 }
+      it 'should return false (move 0,0 to 3,0 another piece on 3,0)' do
+        expect(rook1.is_move_blocked(dest_x,dest_y)).to be false
+      end
+    end
+
     context 'right to left' do
       let!(:rook1) { FactoryGirl.create(:rook, current_position_x: 5, current_position_y: 0) }
       let!(:rook2) { FactoryGirl.create(:rook, current_position_x: 3, current_position_y: 0) }
+      let!(:rook3) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 0) }
       let(:dest_x) { 0 }
       let(:dest_y) { 0 }
       it 'should return true (move 5,0 to 0,0 blocked on 3,0)' do
         expect(rook1.is_move_blocked(dest_x,dest_y)).to be true
       end
     end
+
+    context 'right to left - edge case - piece on destination position' do
+      let!(:rook1) { FactoryGirl.create(:rook, current_position_x: 5, current_position_y: 0) }
+      let!(:rook2) { FactoryGirl.create(:rook, current_position_x: 3, current_position_y: 0) }
+      let(:dest_x) { 3 }
+      let(:dest_y) { 0 }
+      it 'should return false (move 5,0 to 3,0 another piece on 3,0)' do
+        expect(rook1.is_move_blocked(dest_x,dest_y)).to be false
+      end
+    end
+
   end
 
   describe 'piece NOT obstructed horizontally' do
@@ -90,19 +114,42 @@ describe 'piece obstructed vertically' do
   context 'bottom to top' do
     let!(:rook1) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 0) }
     let!(:rook2) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 3) }
+    let!(:rook3) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 5) }
     let(:dest_x) { 0 }
     let(:dest_y) { 5 }
     it 'should return true (move 0,0 to 0,5 blocked on 0,3)' do
       expect(rook1.is_move_blocked(dest_x,dest_y)).to be true
     end
   end
+
+  context 'bottom to top - edge case - piece on destination position' do
+    let!(:rook1) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 0) }
+    let!(:rook2) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 3) }
+    let(:dest_x) { 0 }
+    let(:dest_y) { 3 }
+    it 'should return false (move 0,0 to 0,3 another piece on 0,3)' do
+      expect(rook1.is_move_blocked(dest_x,dest_y)).to be false
+    end
+  end
+
   context 'top to bottom' do
     let!(:rook1) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 5) }
     let!(:rook2) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 3) }
+    let!(:rook3) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 0) }
     let(:dest_x) { 0 }
     let(:dest_y) { 0 }
     it 'should return true (move 0,5 to 0,0 blocked on 0,3)' do
       expect(rook1.is_move_blocked(dest_x,dest_y)).to be true
+    end
+  end
+
+  context 'top to bottom - edge case - piece on destination position' do
+    let!(:rook1) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 5) }
+    let!(:rook2) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 0) }
+    let(:dest_x) { 0 }
+    let(:dest_y) { 0 }
+    it 'should return false (move 0,5 to 0,0, another piece on 0,0)' do
+      expect(rook1.is_move_blocked(dest_x,dest_y)).to be false
     end
   end
 end
@@ -110,6 +157,7 @@ end
 describe 'piece NOT obstructed vertically' do
   let!(:rook1) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 0) }
   let!(:rook2) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 5) }
+  let!(:rook3) { FactoryGirl.create(:rook, current_position_x: 0, current_position_y: 3) }
   let(:dest_x) { 0 }
   let(:dest_y) { 3 }
   it 'should return false (move 0,0 to 0,3)' do
@@ -133,6 +181,16 @@ describe 'piece obstructed diagonally' do
     end
   end
 
+  context 'bottom right to upper left - edge case - piece on destination position' do
+    let!(:bishop1) { FactoryGirl.create(:bishop, current_position_x: 7, current_position_y: 0) }
+    let!(:bishop2) { FactoryGirl.create(:bishop, current_position_x: 3, current_position_y: 4) }
+    let(:dest_x) { 3 }
+    let(:dest_y) { 4 }
+    it 'should return false (move 7,0 to 3,4 -  another piece on 3,4)' do
+      expect(bishop1.is_move_blocked(dest_x,dest_y)).to be false
+    end
+  end
+
   context 'upper right to bottom left' do
     let!(:bishop1) { FactoryGirl.create(:bishop, current_position_x: 0, current_position_y: 7) }
     let!(:bishop2) { FactoryGirl.create(:bishop, current_position_x: 3, current_position_y: 4) }
@@ -142,9 +200,19 @@ describe 'piece obstructed diagonally' do
       expect(bishop1.is_move_blocked(dest_x ,dest_y)).to be true
     end
   end
+
+  context 'upper right to bottom left - edge case - piece on destination position' do
+    let!(:bishop1) { FactoryGirl.create(:bishop, current_position_x: 0, current_position_y: 7) }
+    let!(:bishop2) { FactoryGirl.create(:bishop, current_position_x: 3, current_position_y: 4) }
+    let(:dest_x) { 3 }
+    let(:dest_y) { 4 }
+    it 'should return false (move 0,7 to 3,4 - another piece on 3,4)' do
+      expect(bishop1.is_move_blocked(dest_x ,dest_y)).to be false
+    end
+  end
 end
 
-describe 'piece obstructed bottom left to upper right' do
+describe 'bottom left to upper right' do
   let!(:bishop1) { FactoryGirl.create(:bishop, current_position_x: 0, current_position_y: 0) }
   let!(:bishop2) { FactoryGirl.create(:bishop, current_position_x: 4, current_position_y: 4) }
   let(:dest_x) { 7 }
@@ -154,7 +222,17 @@ describe 'piece obstructed bottom left to upper right' do
   end
 end
 
-describe 'piece obstructed upper right to bottom left' do
+describe 'bottom left to upper right - edge case - piece on destination position' do
+  let!(:bishop1) { FactoryGirl.create(:bishop, current_position_x: 0, current_position_y: 0) }
+  let!(:bishop2) { FactoryGirl.create(:bishop, current_position_x: 4, current_position_y: 4) }
+  let(:dest_x) { 4 }
+  let(:dest_y) { 4 }
+  it 'should return false (move 0,0 to 4,4  - another piece on 4,4)' do
+    expect(bishop1.is_move_blocked(dest_x,dest_y)).to be false
+  end
+end
+
+describe 'upper right to bottom left' do
   let!(:bishop1) { FactoryGirl.create(:bishop, current_position_x: 7, current_position_y: 7) }
   let!(:bishop2) { FactoryGirl.create(:bishop, current_position_x: 4, current_position_y: 4) }
   let(:dest_x) { 0 }
@@ -164,7 +242,17 @@ describe 'piece obstructed upper right to bottom left' do
   end
 end
 
-  describe 'piece NOT obstructed' do
+describe 'upper right to bottom left - edge case - piece on destination position' do
+  let!(:bishop1) { FactoryGirl.create(:bishop, current_position_x: 7, current_position_y: 7) }
+  let!(:bishop2) { FactoryGirl.create(:bishop, current_position_x: 4, current_position_y: 4) }
+  let(:dest_x) { 4 }
+  let(:dest_y) { 4 }
+  it 'should return false (move 7,7 to 4,4 - another piece on 4,4)' do
+    expect(bishop1.is_move_blocked(dest_x,dest_y)).to be false
+  end
+end
+
+describe 'piece NOT obstructed' do
     #one piece in each corner
     let!(:bishop1) { FactoryGirl.create(:bishop, current_position_x: 0, current_position_y: 0) }
     let!(:bishop2) { FactoryGirl.create(:bishop, current_position_x: 0, current_position_y: 7) }


### PR DESCRIPTION
I fixed code, so _is_move_blocked_ method does not “check” if the destination square itself is occupied. Only the intermediary squares.
Added tests too.
