### PR TITLE
Pawn promo

### DIFF
--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,5 +1,6 @@
 class King < Piece
   # KINGS CAN MOVE ONE SQUARE IN ANY DIRECTION
+
   def valid_move?(destination_x, destination_y)
     return false if super(destination_x, destination_y) == false
     (self.current_position_x - destination_x).abs <= 1 && 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -21,4 +21,10 @@ class Pawn < Piece
     return "first_move_white" if self.piece_color == "white" && self.current_position_y == 1
     return "first_move_black" if self.piece_color == "black" && self.current_position_y == 6
   end
+
+  def promote
+    self.piece_type = "Queen" if 
+      (self.piece_color == "white" && self.current_position_y == 7) ||
+      (self.piece_color == "black" && self.current_position_y == 0)
+  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -13,6 +13,12 @@ class Piece < ApplicationRecord
   scope :knights, -> { where(piece_type: 'Knight') }
   scope :pawns,   -> { where(piece_type: 'Pawn') }
 
+  # PIECE_MOVED METHOD
+
+  def has_moved?
+    self.created_at != self.updated_at
+  end
+
   # VALID_MOVE METHOD
 
   def valid_move?(destination_x, destination_y)

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe King, type: :model do
 
   describe "CASTLING" do 
     let!(:king) { FactoryGirl.create(:king, current_position_x: 3, 
-                                            current_position_y: 3) 
+                                            current_position_y: 3) }
     it "checks if king has never moved" do
       expect(king.has_moved?).to be false
     end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -7,7 +7,21 @@ RSpec.describe King, type: :model do
 
   # VALID KING MOVES
 
+    describe "CASTLING" do 
+      let!(:king) { FactoryGirl.create(:king, current_position_x: 3, 
+                                              current_position_y: 3) }
+      
+      #let(:dest_x) { 3 }
+      #let(:dest_y_top) { 4 }
+      #let(:dest_y_bottom) { 2 }
+
+      it "king has never moved" do
+        expect(king.has_moved?).to be false
+      end
+    end
+
   describe "#valid_move? true" do 
+
     context "vertical moves" do 
       let!(:king) { FactoryGirl.create(:king, current_position_x: 3, 
                                               current_position_y: 3) }

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -7,18 +7,13 @@ RSpec.describe King, type: :model do
 
   # VALID KING MOVES
 
-    describe "CASTLING" do 
-      let!(:king) { FactoryGirl.create(:king, current_position_x: 3, 
-                                              current_position_y: 3) }
-      
-      #let(:dest_x) { 3 }
-      #let(:dest_y_top) { 4 }
-      #let(:dest_y_bottom) { 2 }
-
-      it "king has never moved" do
-        expect(king.has_moved?).to be false
-      end
+  describe "CASTLING" do 
+    let!(:king) { FactoryGirl.create(:king, current_position_x: 3, 
+                                            current_position_y: 3) 
+    it "checks if king has never moved" do
+      expect(king.has_moved?).to be false
     end
+  end
 
   describe "#valid_move? true" do 
 

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -13,6 +13,60 @@ RSpec.describe Piece, type: :model do
     expect { FactoryGirl.create(:rook) }.to change { Piece.count }
   end
 
+  it 'has valid factory' do
+    expect { FactoryGirl.create(:pawn) }.to change { Piece.count }
+  end
+
+  it 'has valid factory' do
+    expect { FactoryGirl.create(:queen) }.to change { Piece.count }
+  end
+
+  # PAWN PROMOTION
+
+  describe 'a queen is a queen' do
+    let!(:queen1) { FactoryGirl.create(:queen, current_position_x: 0, current_position_y: 0) }
+    it 'should just be' do
+      expect(queen1.piece_type).to be == "Queen"
+    end
+  end
+
+  describe 'black pawn is promoted' do
+    let!(:pawn1) { FactoryGirl.create(:pawn, piece_color: "black", 
+                   current_position_x: 0, current_position_y: 0) }
+    it 'should be promoted to queen' do
+      pawn1.promote
+      expect(pawn1.piece_type).to be == "Queen"
+    end
+  end
+
+  describe 'black pawn is NOT promoted' do
+    let!(:pawn1) { FactoryGirl.create(:pawn, piece_color: "black", 
+                   current_position_x: 0, current_position_y: 2) }
+    it 'should still be a pawn' do
+      pawn1.promote
+      expect(pawn1.piece_type).to be == "Pawn"
+    end
+  end
+
+  describe 'white pawn is promoted' do
+    let!(:pawn1) { FactoryGirl.create(:pawn, piece_color: "white", 
+                   current_position_x: 0, current_position_y: 7) }
+    it 'should be promoted to queen' do
+      pawn1.promote
+      expect(pawn1.piece_type).to be == "Queen"
+    end
+  end
+
+  describe 'white pawn is NOT promoted' do
+    let!(:pawn1) { FactoryGirl.create(:pawn, piece_color: "white", 
+                   current_position_x: 0, current_position_y: 3) }
+    it 'should still be a pawn' do
+      pawn1.promote
+      expect(pawn1.piece_type).to be == "Pawn"
+    end
+  end
+
+
   # VALID MOVES
 
   describe "valid_move?" do


### PR DESCRIPTION
Here is V1 of pawn promotion: If a pawn reaches the opposing final rank, it is promoted to a queen. Tests included.