### PR TITLE
Fix Database Cleaner Errors With RSpec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'devise'
+require 'database_cleaner'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -30,6 +31,17 @@ require 'devise'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  # Configure database cleaner
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 
   config.include Devise::Test::ControllerHelpers, :type => :controller
   config.include FactoryGirl::Syntax::Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,18 +21,6 @@ SimpleCov.start
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  # Configure database cleaner
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
-  end
-
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
The following errors have been occurring when running RSpec:

`An error occurred in a before(:suite) hook.`

`Failure/Error: DatabaseCleaner.strategy = :transaction`

`NameError:`
 `uninitialized constant DatabaseCleaner`
` ./spec/spec_helper.rb:26:in block (2 levels) in <top (required)>`

`Finished in 0.07484 seconds (files took 2 seconds to load)`
`0 examples, 0 failures, 2 errors occurred outside of examples`

***I've moved the files from `spec/spec_helper.rb` to `spec/rails_helper.rb`***
